### PR TITLE
Seed backend with default train configs & provide that info to front

### DIFF
--- a/apps/backend/src/_dtos/training/available-cached-training-options.dto.ts
+++ b/apps/backend/src/_dtos/training/available-cached-training-options.dto.ts
@@ -1,0 +1,5 @@
+import { TrainingConfigDTO } from '../prediction/training-config.dto';
+
+export type AvailableCachedTrainingOptionsDTO = {
+  [Key in keyof TrainingConfigDTO]: Array<TrainingConfigDTO[Key]>;
+};

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -7,6 +7,7 @@ import { NestApplication, NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import ScaleUtil from './scale-util';
 import { Logger, ValidationPipe } from '@nestjs/common';
+import { CacheModelUtil } from './prediction/cache-model.util';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -15,7 +16,11 @@ async function bootstrap() {
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);
   const port = process.env.PORT || 3000;
-  ScaleUtil.scaleHorizontally(null, listenFunction.bind(this, app, port));
+  ScaleUtil.scaleHorizontally(async () => {
+    Logger.log('Generation of models started');
+    await CacheModelUtil.createAndCacheTfModels();
+    Logger.log('Generation completed');
+  }, listenFunction.bind(this, app, port));
 }
 
 async function listenFunction(

--- a/apps/backend/src/prediction/cache-model.util.ts
+++ b/apps/backend/src/prediction/cache-model.util.ts
@@ -1,0 +1,198 @@
+import path from 'path';
+import {
+  BasicLayer,
+  HelpLayer,
+  LossFn,
+  Optimizer,
+  TrainingConfig,
+} from '../_typings/prediction/training.typings';
+import {
+  Sequential,
+  sequential,
+  layers,
+  losses,
+  train,
+  loadLayersModel,
+  LayersModel,
+} from '@tensorflow/tfjs-node';
+import fs from 'fs';
+import { AvailableCachedTrainingOptionsDTO } from '../_dtos/training/available-cached-training-options.dto';
+
+export class CacheModelUtil {
+  private static readonly CACHED_MODEL_FILES_DESTINATION = path.join(
+    __dirname,
+    'assets/models/'
+  );
+  private static readonly DEFAULT_INPUT_SHAPE: [number, number] = [21, 1];
+  private static readonly DEFAULT_MOMENTUM_VALUE = 20;
+  private static readonly DEFAULT_BASIC_LAYER_UNITS = 50;
+  private static readonly DEFAULT_HELP_LAYER_RATE = 0.2;
+  private static readonly DEFAULT_OUTPUT_LENGTH = 2;
+  private static readonly CACHE_MODEL_STATIC_FILE_NAME = 'model.json';
+
+  private static readonly CACHED_BASIC_LAYERS: Set<BasicLayer> =
+    new Set<BasicLayer>(['lstm', 'gru', 'simpleRNN']);
+  private static readonly CACHED_HELP_LAYERS: Set<HelpLayer> =
+    new Set<HelpLayer>(['batchNormalization', 'dropout']);
+  private static readonly CACHED_LOSS_FN: Set<LossFn> = new Set<LossFn>([
+    'logLoss',
+    'hingeLoss',
+    'huberLoss',
+    'meanSquaredError',
+  ]);
+  private static readonly CACHED_OPTIMIZER: Set<Optimizer> = new Set<Optimizer>(
+    ['sgd', 'rmsprop', 'adam']
+  );
+
+  private static readonly CACHED_LEARNING_RATE: Set<number> = new Set<number>([
+    0.001, 0.1, 1, 10,
+  ]);
+
+  static async resolveModel(
+    trainingConfig: TrainingConfig
+  ): Promise<LayersModel> {
+    const model = await CacheModelUtil.getCachedModel(trainingConfig);
+
+    if (model) {
+      return model;
+    }
+
+    return await CacheModelUtil.cacheSingleModel(trainingConfig);
+  }
+
+  static async createAndCacheTfModels(): Promise<void> {
+    if (CacheModelUtil.hasCachedModels()) {
+      return;
+    }
+
+    for (const basicLayer of CacheModelUtil.CACHED_BASIC_LAYERS) {
+      for (const helpLayer of CacheModelUtil.CACHED_HELP_LAYERS) {
+        for (const lossFn of CacheModelUtil.CACHED_LOSS_FN) {
+          for (const optimizer of CacheModelUtil.CACHED_OPTIMIZER) {
+            for (const learningRate of CacheModelUtil.CACHED_LEARNING_RATE) {
+              await CacheModelUtil.cacheSingleModel({
+                basicLayer,
+                helpLayer,
+                lossFn,
+                optimizer,
+                learningRate,
+              } satisfies TrainingConfig);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  static async getCachedTrainConfigOptions(): Promise<AvailableCachedTrainingOptionsDTO> {
+    return {
+      basicLayer: Array.from(CacheModelUtil.CACHED_BASIC_LAYERS),
+      helpLayer: Array.from(CacheModelUtil.CACHED_HELP_LAYERS),
+      lossFn: Array.from(CacheModelUtil.CACHED_LOSS_FN),
+      optimizer: Array.from(CacheModelUtil.CACHED_OPTIMIZER),
+      learningRate: Array.from(CacheModelUtil.CACHED_LEARNING_RATE),
+    };
+  }
+
+  private static async cacheSingleModel(
+    trainingConfig: TrainingConfig
+  ): Promise<LayersModel> {
+    const model = CacheModelUtil.createSequentialCompiledModel(trainingConfig);
+    const filePath = CacheModelUtil.getCachedModelFilePath(trainingConfig);
+
+    await model.save(filePath);
+    return model;
+  }
+
+  private static async getCachedModel(
+    trainingConfig: TrainingConfig
+  ): Promise<LayersModel> {
+    const filePath = CacheModelUtil.getCachedModelFilePath(trainingConfig);
+
+    const sequentialModel = await loadLayersModel(
+      `${filePath}/${CacheModelUtil.CACHE_MODEL_STATIC_FILE_NAME}`
+    );
+
+    sequentialModel.compile({
+      loss: losses[trainingConfig.lossFn],
+      optimizer:
+        trainingConfig.optimizer === 'momentum'
+          ? train.momentum(
+              trainingConfig.learningRate,
+              CacheModelUtil.DEFAULT_MOMENTUM_VALUE
+            )
+          : train[trainingConfig.optimizer](trainingConfig.learningRate),
+    });
+    return sequentialModel;
+  }
+
+  private static createSequentialCompiledModel(
+    trainingConfig: TrainingConfig,
+    inputShape: [number, number] = CacheModelUtil.DEFAULT_INPUT_SHAPE,
+    basicLayerUnits: number = CacheModelUtil.DEFAULT_BASIC_LAYER_UNITS,
+    returnSequences: boolean = false,
+    helpLayerRate: number = CacheModelUtil.DEFAULT_HELP_LAYER_RATE,
+    outputLength: number = CacheModelUtil.DEFAULT_OUTPUT_LENGTH
+  ): Sequential {
+    const sequentialModel: Sequential = sequential();
+
+    sequentialModel.add(
+      layers[trainingConfig.basicLayer]({
+        units: basicLayerUnits,
+        inputShape,
+        returnSequences,
+      })
+    );
+
+    sequentialModel.add(
+      layers[trainingConfig.helpLayer]({
+        rate: helpLayerRate,
+      })
+    );
+
+    sequentialModel.add(
+      layers.dense({
+        units: outputLength,
+      })
+    );
+
+    sequentialModel.compile({
+      loss: losses[trainingConfig.lossFn],
+      optimizer:
+        trainingConfig.optimizer === 'momentum'
+          ? train.momentum(
+              trainingConfig.learningRate,
+              CacheModelUtil.DEFAULT_MOMENTUM_VALUE
+            )
+          : train[trainingConfig.optimizer](trainingConfig.learningRate),
+    });
+
+    return sequentialModel;
+  }
+
+  private static getCachedModelFilePath(
+    trainingConfig: TrainingConfig
+  ): string {
+    return (
+      `file://${CacheModelUtil.CACHED_MODEL_FILES_DESTINATION}` +
+      Object.keys(trainingConfig)
+        .sort()
+        .map((key) => trainingConfig[key])
+        .join('_')
+    );
+  }
+
+  private static hasCachedModels(): boolean {
+    const filenamesFromCacheDestination = fs.readdirSync(
+      CacheModelUtil.CACHED_MODEL_FILES_DESTINATION
+    );
+    return (
+      filenamesFromCacheDestination.length >=
+      CacheModelUtil.CACHED_BASIC_LAYERS.size *
+        CacheModelUtil.CACHED_HELP_LAYERS.size *
+        CacheModelUtil.CACHED_LOSS_FN.size *
+        CacheModelUtil.CACHED_LEARNING_RATE.size *
+        CacheModelUtil.CACHED_OPTIMIZER.size
+    );
+  }
+}

--- a/apps/backend/src/prediction/prediction.controller.ts
+++ b/apps/backend/src/prediction/prediction.controller.ts
@@ -1,7 +1,9 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { PredictionService } from './prediction.service';
 import { PredictionDataDTO } from '../_dtos/prediction/prediction-data.dto';
 import { GeneratedPredictionDTO } from '../_dtos/prediction/generated-prediction.dto';
+import { AvailableCachedTrainingOptionsDTO } from '../_dtos/training/available-cached-training-options.dto';
+import { CacheModelUtil } from './cache-model.util';
 
 @Controller('prediction')
 export class PredictionController {
@@ -15,5 +17,10 @@ export class PredictionController {
       predictionDataDTO.data,
       predictionDataDTO.trainingConfig
     );
+  }
+
+  @Get('cached-train-config')
+  async getCachedTrainConfigOptions(): Promise<AvailableCachedTrainingOptionsDTO> {
+    return CacheModelUtil.getCachedTrainConfigOptions();
   }
 }

--- a/apps/backend/src/scale-util.ts
+++ b/apps/backend/src/scale-util.ts
@@ -1,23 +1,26 @@
 import cluster from 'cluster';
 import * as os from 'os';
 
-type FunctionCb = (...args: any[]) => void;
+type FunctionCb = (...args: any[]) => Promise<void>;
 
 export type ScaleOps = {
-  scaleHorizontally(masterCb: FunctionCb, slaveCb: FunctionCb): void;
+  scaleHorizontally(masterCb: FunctionCb, slaveCb: FunctionCb): Promise<void>;
 };
 
 class ScaleUtil implements ScaleOps {
   private static readonly CPUS_COUNT = os.cpus().length;
 
-  scaleHorizontally(masterCb?: FunctionCb, slaveCb?: FunctionCb): void {
+  async scaleHorizontally(
+    masterCb?: FunctionCb,
+    slaveCb?: FunctionCb
+  ): Promise<void> {
     if (cluster.isPrimary) {
+      await masterCb?.();
       this.respawnProcesses();
-      masterCb?.();
       return;
     }
 
-    slaveCb?.();
+    await slaveCb?.();
   }
 
   private respawnProcesses(): void {

--- a/apps/frontend/src/app/_dtos/prediction/available-cached-training-options.dto.ts
+++ b/apps/frontend/src/app/_dtos/prediction/available-cached-training-options.dto.ts
@@ -1,0 +1,5 @@
+import { TrainingConfig } from '../../_typings/workspace/sidebar-config.typings';
+
+export type AvailableCachedTrainingOptionsDTO = {
+  [Key in keyof TrainingConfig]: Array<TrainingConfig[Key]>;
+};

--- a/apps/frontend/src/app/_helpers/training-converter.ts
+++ b/apps/frontend/src/app/_helpers/training-converter.ts
@@ -10,7 +10,7 @@ export class TrainingConverter {
         return 'gru' as any;
       case 'LSTM':
         return 'lstm' as any;
-      case 'SimpleRNN' as any:
+      case 'SimpleRNN':
         return 'simpleRNN' as any;
       case 'Dropout':
         return 'dropout' as any;

--- a/apps/frontend/src/app/_resolvers/cached-train-config.resolver.spec.ts
+++ b/apps/frontend/src/app/_resolvers/cached-train-config.resolver.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { ResolveFn } from '@angular/router';
+
+import { cachedTrainConfigResolver } from './cached-train-config.resolver';
+
+describe('cachedTrainConfigResolver', () => {
+  const executeResolver: ResolveFn<boolean> = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() =>
+      cachedTrainConfigResolver(...resolverParameters)
+    );
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeResolver).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/app/_resolvers/cached-train-config.resolver.ts
+++ b/apps/frontend/src/app/_resolvers/cached-train-config.resolver.ts
@@ -1,0 +1,10 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { PredictionService } from '../_services/prediction.service';
+import { AvailableCachedTrainingOptionsDTO } from '../_dtos/prediction/available-cached-training-options.dto';
+
+export const cachedTrainConfigResolver: ResolveFn<
+  AvailableCachedTrainingOptionsDTO
+> = () => {
+  return inject(PredictionService).getCachedPredictionConfig();
+};

--- a/apps/frontend/src/app/_services/prediction.service.ts
+++ b/apps/frontend/src/app/_services/prediction.service.ts
@@ -5,6 +5,7 @@ import { TrainingConfig } from '../_typings/workspace/sidebar-config.typings';
 import { environment } from '../../environments/environment.development';
 import { GeneratedPredictionDTO } from '../_dtos/prediction/generated-prediction.dto';
 import { TrainingConverter } from '../_helpers/training-converter';
+import { AvailableCachedTrainingOptionsDTO } from '../_dtos/prediction/available-cached-training-options.dto';
 
 @Injectable({
   providedIn: 'root',
@@ -33,7 +34,13 @@ export class PredictionService {
     );
   }
 
+  getCachedPredictionConfig(): Observable<AvailableCachedTrainingOptionsDTO> {
+    return this.httpClient.get<AvailableCachedTrainingOptionsDTO>(
+      `${this.getBackendUrl()}/prediction/cached-train-config`
+    );
+  }
+
   private getBackendUrl(): string {
-    return `${environment.backend_url}api`;
+    return environment.backend_url;
   }
 }

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { cachedTrainConfigResolver } from './_resolvers/cached-train-config.resolver';
 
 export const routes: Routes = [
   {
@@ -12,5 +13,8 @@ export const routes: Routes = [
       import('./workspace/workspace.component').then(
         (module) => module.WorkspaceComponent
       ),
+    resolve: {
+      cachedTrainConfig: cachedTrainConfigResolver,
+    },
   },
 ];

--- a/apps/frontend/src/app/sidebar/sidebar.component.html
+++ b/apps/frontend/src/app/sidebar/sidebar.component.html
@@ -33,12 +33,6 @@
                   href="#"
                   >Sign In</a
                 >
-                <!-- <span class="text-slate-300">|</span>
-                    <a
-                      class="py-1 px-2 rounded-full transition-all border border-transparent hover:border-slate-200"
-                      href="#"
-                      >Log In</a
-                    > -->
               </span>
             </p>
           </div>
@@ -112,9 +106,14 @@
                   <mat-select [formControlName]="'basicLayer'">
                     @for (basicLayerOption of basicLayerOptions; track
                     basicLayerOption) {
-                    <mat-option [value]="basicLayerOption.value">{{
-                      basicLayerOption.viewValue
-                    }}</mat-option>
+                    <mat-option [value]="basicLayerOption.value" dir="rtl">
+                      <span class="pl-4">{{ basicLayerOption.viewValue }}</span>
+                      @if
+                      (this.cachedTrainConfigOpts()?.['basicLayer']?.includes(convertLayerOption(basicLayerOption.value)))
+                      {
+                      <mat-icon class="!m-0 scale-75">cached</mat-icon>
+                      }
+                    </mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
@@ -131,9 +130,16 @@
                   <mat-select [formControlName]="'helpLayer'">
                     @for (helpLayerOption of helpLayerOptions; track
                     helpLayerOption) {
-                    <mat-option [value]="helpLayerOption.value">{{
-                      helpLayerOption.viewValue
-                    }}</mat-option>
+                    <mat-option [value]="helpLayerOption.value" dir="rtl"
+                      ><span class="pl-4"
+                        >{{ helpLayerOption.viewValue }}
+                      </span>
+                      @if
+                      (this.cachedTrainConfigOpts()?.['helpLayer']?.includes(convertLayerOption(helpLayerOption.value)))
+                      {
+                      <mat-icon class="!mr-2 scale-75">cached</mat-icon>
+                      }</mat-option
+                    >
                     }
                   </mat-select>
                 </mat-form-field>
@@ -149,9 +155,16 @@
                   <mat-label>Loss Function</mat-label>
                   <mat-select [formControlName]="'lossFn'">
                     @for (lossFnOption of lossFnOptions; track lossFnOption) {
-                    <mat-option [value]="lossFnOption.value">{{
-                      lossFnOption.viewValue
-                    }}</mat-option>
+                    <mat-option [value]="lossFnOption.value" dir="rtl">
+                      <span class="pl-4">
+                        {{ lossFnOption.viewValue }}
+                      </span>
+                      @if
+                      (this.cachedTrainConfigOpts()?.['lossFn']?.includes(lossFnOption.value))
+                      {
+                      <mat-icon class="!mr-2 scale-75">cached</mat-icon>
+                      }
+                    </mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
@@ -168,9 +181,19 @@
                     <mat-select [formControlName]="'optimizer'">
                       @for (optimizerOption of optimizerOptions; track
                       optimizerOption) {
-                      <mat-option [value]="optimizerOption.value">{{
-                        optimizerOption.viewValue
-                      }}</mat-option>
+                      <mat-option
+                        [value]="optimizerOption.value"
+                        dir="rtl"
+                        class="!p-0 !pr-1"
+                        ><span class="pl-4">{{
+                          optimizerOption.viewValue
+                        }}</span>
+                        @if
+                        (this.cachedTrainConfigOpts()?.['optimizer']?.includes(optimizerOption.value))
+                        {
+                        <mat-icon class="!mr-2 scale-75">cached</mat-icon>
+                        }
+                      </mat-option>
                       }
                     </mat-select>
                   </mat-form-field>

--- a/apps/frontend/src/app/sidebar/sidebar.component.ts
+++ b/apps/frontend/src/app/sidebar/sidebar.component.ts
@@ -1,4 +1,11 @@
-import { Component, DestroyRef, inject, OnInit, output } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  inject,
+  input,
+  OnInit,
+  output,
+} from '@angular/core';
 import {
   FormControl,
   FormGroup,
@@ -41,6 +48,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
+import { AvailableCachedTrainingOptionsDTO } from '../_dtos/prediction/available-cached-training-options.dto';
+import { TrainingConverter } from '../_helpers/training-converter';
 
 @Component({
   selector: 'app-sidebar',
@@ -60,6 +69,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 export class SidebarComponent implements OnInit {
   private readonly store = inject(Store);
   readonly #destroyRef = inject(DestroyRef);
+  readonly cachedTrainConfigOpts = input<AvailableCachedTrainingOptionsDTO>();
 
   excludedOptimizersFromLearningRate: Array<Optimizer> = ['adadelta'];
   private readonly localStorageService = inject(LocalStorageService);
@@ -114,6 +124,10 @@ export class SidebarComponent implements OnInit {
     this.observeFileSaveConfigChanged();
     this.observeChartConfigChanged();
     this.observeTrainingConfigChanged();
+  }
+
+  convertLayerOption<T>(layer: T): T {
+    return TrainingConverter.convertLayerToTensorFn(layer as any);
   }
 
   private loadConfigsFromLocalStorage(): void {

--- a/apps/frontend/src/app/workspace/workspace.component.html
+++ b/apps/frontend/src/app/workspace/workspace.component.html
@@ -22,7 +22,7 @@
   </div>
   <div class="row-span-4 col-start-4 row-start-1 hidden sm:block">
     <ng-template #sidebarTemplateRef>
-      <app-sidebar />
+      <app-sidebar [cachedTrainConfigOpts]="cachedTrainConfigOpts" />
     </ng-template>
     <ng-container *ngTemplateOutlet="sidebarTemplateRef"></ng-container>
   </div>

--- a/apps/frontend/src/app/workspace/workspace.component.ts
+++ b/apps/frontend/src/app/workspace/workspace.component.ts
@@ -63,6 +63,8 @@ import { ActionButtonConfig } from '../_typings/action-buttons/action-buttons.ty
 import { ActionButtonComponent } from '../action-button/action-button.component';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { PredictionService } from '../_services/prediction.service';
+import { ActivatedRoute } from '@angular/router';
+import { AvailableCachedTrainingOptionsDTO } from '../_dtos/prediction/available-cached-training-options.dto';
 
 @Component({
   selector: 'app-workspace',
@@ -105,9 +107,11 @@ export class WorkspaceComponent implements OnInit {
   readonly #destroyRef = inject(DestroyRef);
   private readonly alertService = inject(AlertService);
   private readonly predictionService = inject(PredictionService);
+  private readonly activatedRoute = inject(ActivatedRoute);
 
   private trainingConfig?: TrainingConfig;
   private fileSaveConfig?: FileSave;
+  cachedTrainConfigOpts?: AvailableCachedTrainingOptionsDTO;
 
   isMobile$: Observable<boolean> = inject(BreakpointObserver)
     .observe([Breakpoints.XSmall])
@@ -244,6 +248,8 @@ export class WorkspaceComponent implements OnInit {
     this.observeSidebarConfigChanged();
     this.observeWorksheetData();
     this.generateRandomData();
+
+    this.observeCachedTrainConfigOptions();
   }
 
   openLoadDataModal(): void {
@@ -564,5 +570,11 @@ export class WorkspaceComponent implements OnInit {
       this.chartComponent().update();
       this.changeDetectorRef.detectChanges();
     }
+  }
+
+  private observeCachedTrainConfigOptions(): void {
+    this.activatedRoute.data.subscribe((data) => {
+      this.cachedTrainConfigOpts = data['cachedTrainConfig'];
+    });
   }
 }

--- a/apps/frontend/src/environments/environment.development.ts
+++ b/apps/frontend/src/environments/environment.development.ts
@@ -4,5 +4,5 @@ export const environment = {
   aws_s3_bucket_access_key_id: '',
   aws_s3_bucket_secret_access_key: '',
   aws_s3_bucket_default_files_prefix: '',
-  backend_url: 'http://localhost:3000/',
+  backend_url: 'http://localhost:3000/api',
 };

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -21,8 +21,21 @@ html {
   );
 }
 
+@function is-important($important) {
+  @return #{if($important, '!important', '')};
+}
+
+@mixin native-font($important: false) {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace is-important($important);
+}
+
 * {
-  @apply font-mono;
+  @include native-font();
+}
+
+.mat-mdc-option {
+  @include native-font(!important);
 }
 
 body {


### PR DESCRIPTION
During bootstrap of backend app, seeding of 'cached' models (saving info to separate files) is provided. Later on, user can see which option is already cached and ready to go (no need to create model once again).
