### PR TITLE
Rewrite stop prediction feature in bullmq routine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ node_modules
 **/*.pbsc.ts
 **/*.pbconf.ts
 **/*pb.ts
+**/*.krpref
+**/*.krproj
+**/*.krenv
+**/PredictionService/*
 
 # exe
 **/*.exe

--- a/apps/backend/src/.proto/prediction.proto
+++ b/apps/backend/src/.proto/prediction.proto
@@ -11,5 +11,12 @@ message PredictionProgressRequest {
 }
 
 message PredictionProgressResponse {
+    /**
+     * Progress of prediciton. That's the natural number between 0 (start) and 100 (finish).
+     */
     int32 progress = 1;
+    /**
+     * List of result, present when prediction is finished.
+     */
+    repeated int32 result = 2;
 }

--- a/apps/backend/src/app/_dtos/prediction/stop-prediction.dto.ts
+++ b/apps/backend/src/app/_dtos/prediction/stop-prediction.dto.ts
@@ -1,0 +1,1 @@
+export class StopPredictionDTO {}

--- a/apps/backend/src/app/_helpers/type-helper.ts
+++ b/apps/backend/src/app/_helpers/type-helper.ts
@@ -1,0 +1,10 @@
+export class TypeHelper {
+  static isTwoNumberTuple(object: unknown): object is [number, number] {
+    return (
+      object &&
+      Array.isArray(object) &&
+      object.length === 2 &&
+      object.every((entry) => Number.isFinite(entry))
+    );
+  }
+}

--- a/apps/backend/src/app/_queues/consumers/train-model.consumer.ts
+++ b/apps/backend/src/app/_queues/consumers/train-model.consumer.ts
@@ -1,33 +1,14 @@
-import { Processor, OnWorkerEvent, WorkerHost } from '@nestjs/bullmq';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { TrainModelWorker } from '../../_workers/train-model.worker';
-import { ComputeInteractUtil } from '../../util/compute-interact.util';
 import { OutputPrediction } from '../../_typings/prediction/prediction.typings';
+import { WorkerMessageFitPayload } from '../../_typings/prediction/training.typings';
 
-@Processor({ name: 'prediction' })
+@Processor({ name: 'prediction' }, { maxStalledCount: 0 })
 export class PredictionConsumer extends WorkerHost {
-  async process(job: Job<any, any, string>): Promise<OutputPrediction> {
-    ComputeInteractUtil.ABORT_CONTROLLER.signal.addEventListener(
-      'abort',
-      async () => {
-        try {
-          await job.remove();
-        } catch (err: unknown) {
-          console.log(err);
-        }
-      }
-    );
-
+  async process(
+    job: Job<WorkerMessageFitPayload, OutputPrediction, string>
+  ): Promise<OutputPrediction> {
     return await TrainModelWorker.trainModel(job.data, job.id);
-  }
-
-  @OnWorkerEvent('completed')
-  onCompleted() {
-    console.log('Queue is completed');
-  }
-
-  @OnWorkerEvent('failed')
-  onComputationFailed() {
-    console.log('Queue failed');
   }
 }

--- a/apps/backend/src/app/_typings/ipc/ipc.typings.d.ts
+++ b/apps/backend/src/app/_typings/ipc/ipc.typings.d.ts
@@ -1,0 +1,33 @@
+export type ProcessActionType =
+  | 'cancel'
+  | 'register-training'
+  | 'unregister-training'
+  | 'training-begin'
+  | 'training-progress';
+
+export type ProcessSendBasePayload = {
+  jobId: string;
+};
+
+export type CancelTrainingSendPayload = {
+  action: 'cancel';
+};
+
+export type DeregisterTrainingSendPayload = {
+  action: 'unregister-training' | 'register-training';
+  pid: number;
+};
+
+export type TrainingProgressSendPayload = {
+  action: 'training-begin' | 'training-progress';
+  computationProgress: number;
+  pid: number;
+  result?: [number, number];
+};
+
+export type ProcessSendPayload = ProcessSendBasePayload &
+  (
+    | TrainingProgressSendPayload
+    | DeregisterTrainingSendPayload
+    | CancelTrainingSendPayload
+  );

--- a/apps/backend/src/app/_typings/ipc/ipc.typings.d.ts
+++ b/apps/backend/src/app/_typings/ipc/ipc.typings.d.ts
@@ -1,3 +1,5 @@
+import type { Worker } from 'cluster';
+
 export type ProcessActionType =
   | 'cancel'
   | 'register-training'
@@ -31,3 +33,9 @@ export type ProcessSendPayload = ProcessSendBasePayload &
     | DeregisterTrainingSendPayload
     | CancelTrainingSendPayload
   );
+
+export type ListenToProcessMessageEventPayload =
+  | {
+      workers: NodeJS.Dict<Worker>;
+    }
+  | { worker: Worker };

--- a/apps/backend/src/app/_typings/prediction/prediction.typings.ts
+++ b/apps/backend/src/app/_typings/prediction/prediction.typings.ts
@@ -23,6 +23,7 @@ export type WorkerMessage = {
     lastDataFromPast: number[][];
     pastData: Array<number>;
     sequenceLength: number;
+    pid: number;
   };
 };
 

--- a/apps/backend/src/app/_workers/train-model.worker.ts
+++ b/apps/backend/src/app/_workers/train-model.worker.ts
@@ -14,6 +14,7 @@ import type {
   TensorLike2D,
   TensorLike3D,
 } from '../_typings/tensorflow/tfjs_supp';
+import { IpcHandler } from '../ipc/ipc.handler';
 
 export const filename = resolve(__filename);
 
@@ -24,6 +25,7 @@ type PredictionStatusRequest = {
 type ComputationProgress = {
   progress: number;
   jobId: string;
+  result?: [number, number];
 };
 
 @Controller()
@@ -36,14 +38,18 @@ export class TrainModelWorker {
   @GrpcMethod('PredictionService', 'ObserveProgress')
   observeProgress(
     predictionStatusRequest: PredictionStatusRequest
-  ): Observable<Pick<ComputationProgress, 'progress'>> {
+  ): Observable<Pick<ComputationProgress, 'progress' | 'result'>> {
     const jobId = predictionStatusRequest['jobId'];
+
     return TrainModelWorker.COMPUTATION_PROGRESS$.pipe(
       filter(
         (computationProgress) =>
           !!computationProgress && computationProgress?.jobId === jobId
       ),
-      map(({ progress }) => ({ progress }))
+      map(({ progress, result }) => {
+        console.log('w', progress, result, process.pid, process.ppid);
+        return { progress, result };
+      })
     );
   }
 
@@ -51,6 +57,13 @@ export class TrainModelWorker {
     workerMessageFitPayload: WorkerMessageFitPayload,
     jobId: string
   ): Promise<OutputPrediction> {
+    console.log('registerd process', process.pid);
+    IpcHandler.sendMessage({
+      pid: process.pid,
+      jobId,
+      action: 'register-training',
+    });
+
     const {
       trainingConfig: {
         optimizer,
@@ -85,17 +98,11 @@ export class TrainModelWorker {
       verbose: 0,
       callbacks: {
         onTrainBegin: () => {
-          process.send({
+          IpcHandler.sendMessage({
             pid: process.pid,
             computationProgress: 0,
             jobId,
-          });
-        },
-        onTrainEnd: () => {
-          process.send({
-            pid: process.pid,
-            computationProgress: 100,
-            jobId,
+            action: 'training-begin',
           });
         },
         onEpochBegin: async (epoch) => {
@@ -103,10 +110,11 @@ export class TrainModelWorker {
             (epoch / (epochs * batchSize)) * 100
           );
           if (progressValue % 10 === 0) {
-            process.send({
+            IpcHandler.sendMessage({
               pid: process.pid,
               computationProgress: progressValue,
               jobId,
+              action: 'training-progress',
             });
           }
         },
@@ -119,10 +127,12 @@ export class TrainModelWorker {
     const prediction = model.predict(lastDataFromPastTensor) as any;
     const result = Object.values(prediction.dataSync()) as OutputPrediction;
 
-    process.send({
+    IpcHandler.sendMessage({
       pid: process.pid,
-      predictionResult: result,
+      result,
+      computationProgress: 100,
       jobId,
+      action: 'training-progress',
     });
     return result;
   }

--- a/apps/backend/src/app/_workers/train-model.worker.ts
+++ b/apps/backend/src/app/_workers/train-model.worker.ts
@@ -47,7 +47,6 @@ export class TrainModelWorker {
           !!computationProgress && computationProgress?.jobId === jobId
       ),
       map(({ progress, result }) => {
-        console.log('w', progress, result, process.pid, process.ppid);
         return { progress, result };
       })
     );
@@ -57,7 +56,6 @@ export class TrainModelWorker {
     workerMessageFitPayload: WorkerMessageFitPayload,
     jobId: string
   ): Promise<OutputPrediction> {
-    console.log('registerd process', process.pid);
     IpcHandler.sendMessage({
       pid: process.pid,
       jobId,

--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -1,7 +1,5 @@
 import { Module } from '@nestjs/common';
 import { PredictionModule } from './prediction/prediction.module';
-import { APP_INTERCEPTOR } from '@nestjs/core';
-import { CancelRequestInterceptor } from './_interceptors/cancel-request.interceptor';
 import { BullModule } from '@nestjs/bullmq';
 
 @Module({
@@ -10,6 +8,10 @@ import { BullModule } from '@nestjs/bullmq';
       connection: {
         port: 6379,
         host: 'localhost',
+      },
+      defaultJobOptions: {
+        removeOnFail: true,
+        removeOnComplete: true,
       },
     }),
     PredictionModule,

--- a/apps/backend/src/app/ipc/ipc.handler.ts
+++ b/apps/backend/src/app/ipc/ipc.handler.ts
@@ -1,7 +1,11 @@
+import { ScaleUtil } from '../../scale-util';
 import { TypeHelper } from '../_helpers/type-helper';
-import { ProcessSendPayload } from '../_typings/ipc/ipc.typings';
+import {
+  ListenToProcessMessageEventPayload,
+  ProcessSendPayload,
+} from '../_typings/ipc/ipc.typings';
 import { TrainModelWorker } from '../_workers/train-model.worker';
-import { Worker } from 'cluster';
+import { ComputeInteractUtil } from '../util/compute-interact.util';
 
 export class IpcHandler {
   private static readonly JOB_ID_TO_TRAIN_PROCESS_ID_MAP = new Map<
@@ -13,9 +17,16 @@ export class IpcHandler {
     process.send(payload);
   }
 
-  static listenToMessageEvent(workers: NodeJS.Dict<Worker>): void {
-    for (const id in workers) {
-      workers[id].on('message', IpcHandler.handleMessage);
+  static listenToMessageEvent(
+    payload: ListenToProcessMessageEventPayload
+  ): void {
+    if ('worker' in payload) {
+      payload.worker.on('message', IpcHandler.handleMessage);
+      return;
+    }
+
+    for (const id in payload.workers) {
+      payload.workers[id].on('message', IpcHandler.handleMessage);
     }
   }
 
@@ -23,13 +34,13 @@ export class IpcHandler {
     switch (payload.action) {
       case 'cancel':
         {
+          ComputeInteractUtil.ABORT_CONTROLLER.abort('Computation cancelled');
+
           const jobId = payload.jobId;
           const pidToKill =
             IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP.get(jobId);
-          console.log(IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP);
 
           if (pidToKill != null) {
-            console.log('Process is about to be killed');
             IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP.delete(jobId);
             process.kill(pidToKill);
           } else {

--- a/apps/backend/src/app/ipc/ipc.handler.ts
+++ b/apps/backend/src/app/ipc/ipc.handler.ts
@@ -1,0 +1,72 @@
+import { TypeHelper } from '../_helpers/type-helper';
+import { ProcessSendPayload } from '../_typings/ipc/ipc.typings';
+import { TrainModelWorker } from '../_workers/train-model.worker';
+import { Worker } from 'cluster';
+
+export class IpcHandler {
+  private static readonly JOB_ID_TO_TRAIN_PROCESS_ID_MAP = new Map<
+    string,
+    number
+  >();
+
+  static sendMessage(payload: ProcessSendPayload): void {
+    process.send(payload);
+  }
+
+  static listenToMessageEvent(workers: NodeJS.Dict<Worker>): void {
+    for (const id in workers) {
+      workers[id].on('message', IpcHandler.handleMessage);
+    }
+  }
+
+  private static handleMessage(payload: ProcessSendPayload): void {
+    switch (payload.action) {
+      case 'cancel':
+        {
+          const jobId = payload.jobId;
+          const pidToKill =
+            IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP.get(jobId);
+          console.log(IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP);
+
+          if (pidToKill != null) {
+            console.log('Process is about to be killed');
+            IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP.delete(jobId);
+            process.kill(pidToKill);
+          } else {
+            console.log('Cannot kill process - not exist in map');
+          }
+        }
+        break;
+      case 'register-training':
+        {
+          console.log('Training registered');
+          const [jobId, pid] = [payload.jobId, payload.pid];
+          IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP.set(jobId, pid);
+        }
+        break;
+      case 'unregister-training':
+        {
+          const jobId = payload.jobId;
+          IpcHandler.JOB_ID_TO_TRAIN_PROCESS_ID_MAP.delete(jobId);
+        }
+        break;
+      case 'training-begin':
+      case 'training-progress':
+        {
+          const [jobId, progress] = [
+            payload.jobId,
+            payload.computationProgress,
+          ];
+          TrainModelWorker.COMPUTATION_PROGRESS$.next({
+            jobId,
+            progress,
+            ...('result' in payload &&
+            TypeHelper.isTwoNumberTuple(payload.result)
+              ? { result: payload.result }
+              : {}),
+          });
+        }
+        break;
+    }
+  }
+}

--- a/apps/backend/src/app/prediction/prediction.controller.ts
+++ b/apps/backend/src/app/prediction/prediction.controller.ts
@@ -1,9 +1,18 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { PredictionService } from './prediction.service';
 import { PredictionDataDTO } from '../_dtos/prediction/prediction-data.dto';
 import { ScheduledPredictionDTO } from '../_dtos/prediction/scheduled-prediction.dto';
 import { AvailableCachedTrainingOptionsDTO } from '../_dtos/training/available-cached-training-options.dto';
 import { CacheModelUtil } from './cache-model.util';
+import { StopPredictionDTO } from '../_dtos/prediction/stop-prediction.dto';
 
 @Controller('prediction')
 export class PredictionController {
@@ -17,6 +26,14 @@ export class PredictionController {
       predictionDataDTO.data,
       predictionDataDTO.trainingConfig
     );
+  }
+
+  @Delete('stop/:jobId')
+  async stopPrediction(
+    @Param('jobId') jobId: string
+  ): Promise<StopPredictionDTO> {
+    await this.predictionService.stopPrediction(jobId);
+    return {};
   }
 
   @Get('cached-train-config')

--- a/apps/backend/src/app/prediction/prediction.controller.ts
+++ b/apps/backend/src/app/prediction/prediction.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  Post,
-  Query,
-} from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { PredictionService } from './prediction.service';
 import { PredictionDataDTO } from '../_dtos/prediction/prediction-data.dto';
 import { ScheduledPredictionDTO } from '../_dtos/prediction/scheduled-prediction.dto';

--- a/apps/backend/src/app/prediction/prediction.service.ts
+++ b/apps/backend/src/app/prediction/prediction.service.ts
@@ -3,7 +3,6 @@ import type { TrainingConfig } from '../_typings/prediction/training.typings';
 import { ScheduledPredictionDTO } from '../_dtos/prediction/scheduled-prediction.dto';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Job, Queue } from 'bullmq';
-import { ComputeInteractUtil } from '../util/compute-interact.util';
 import { IpcHandler } from '../ipc/ipc.handler';
 
 @Injectable()
@@ -69,10 +68,6 @@ export class PredictionService {
       pid: process.pid,
     });
 
-    setTimeout(async () => {
-      ComputeInteractUtil.ABORT_CONTROLLER.abort();
-    }, 2000);
-
     return {
       jobId: trainModelWorker.id,
     };
@@ -90,7 +85,6 @@ export class PredictionService {
   }
 
   async stopPrediction(jobId: string): Promise<void> {
-    await this.predictionQueue.remove(jobId);
     IpcHandler.sendMessage({
       action: 'cancel',
       jobId,

--- a/apps/backend/src/app/prediction/prediction.service.ts
+++ b/apps/backend/src/app/prediction/prediction.service.ts
@@ -4,6 +4,7 @@ import { ScheduledPredictionDTO } from '../_dtos/prediction/scheduled-prediction
 import { InjectQueue } from '@nestjs/bullmq';
 import { Job, Queue } from 'bullmq';
 import { ComputeInteractUtil } from '../util/compute-interact.util';
+import { IpcHandler } from '../ipc/ipc.handler';
 
 @Injectable()
 export class PredictionService {
@@ -65,6 +66,7 @@ export class PredictionService {
       sequenceLength,
       batchSize,
       epochs: epochSize,
+      pid: process.pid,
     });
 
     setTimeout(async () => {
@@ -85,5 +87,13 @@ export class PredictionService {
     }
 
     return predictionJob.data;
+  }
+
+  async stopPrediction(jobId: string): Promise<void> {
+    await this.predictionQueue.remove(jobId);
+    IpcHandler.sendMessage({
+      action: 'cancel',
+      jobId,
+    });
   }
 }

--- a/apps/backend/src/scale-util.ts
+++ b/apps/backend/src/scale-util.ts
@@ -1,7 +1,6 @@
 import cluster from 'cluster';
 import * as os from 'os';
-import { Worker } from 'cluster';
-import { TrainModelWorker } from './app/_workers/train-model.worker';
+import { IpcHandler } from './app/ipc/ipc.handler';
 
 type FunctionCb = (...args: any[]) => Promise<void>;
 
@@ -18,50 +17,23 @@ class ScaleUtil implements ScaleOps {
   ): Promise<void> {
     if (cluster.isPrimary) {
       await masterCb?.();
-      this.listenToMessageEvent(this.respawnProcesses());
+      this.respawnProcesses();
+      IpcHandler.listenToMessageEvent(cluster.workers);
       return;
     }
 
-    process.on('message', () => {
-      console.log('wtff', process.pid);
-    });
     await slaveCb?.();
   }
 
-  private respawnProcesses(): Map<number, Worker> {
-    const workersMap = new Map<number, Worker>();
+  private respawnProcesses(): void {
     for (let i = 0; i < ScaleUtil.CPUS_COUNT; i++) {
-      const worker = cluster.fork();
-      workersMap.set(worker.id, worker);
+      cluster.fork();
     }
 
     cluster.on('exit', (worker) => {
       console.log(`Worker with id ${worker.process.pid} died. Restarting...`);
       cluster.fork();
     });
-    return workersMap;
-  }
-
-  private listenToMessageEvent(workersMap: Map<number, Worker>): void {
-    for (const id in cluster.workers) {
-      cluster.workers[id].on(
-        'message',
-        (message: Record<'pid' | 'computationProgress' | 'jobId', number>) => {
-          const [pid, progress, jobId] = [
-            message.pid,
-            message.computationProgress,
-            message.jobId + '',
-          ];
-          if (pid && progress && jobId) {
-            // console.log('pid', process.pid, message.jobId);
-            TrainModelWorker.COMPUTATION_PROGRESS$.next({
-              jobId,
-              progress,
-            });
-          }
-        }
-      );
-    }
   }
 }
 

--- a/apps/backend/src/scale-util.ts
+++ b/apps/backend/src/scale-util.ts
@@ -1,4 +1,4 @@
-import cluster from 'cluster';
+import cluster, { Worker } from 'cluster';
 import * as os from 'os';
 import { IpcHandler } from './app/ipc/ipc.handler';
 
@@ -8,8 +8,9 @@ export type ScaleOps = {
   scaleHorizontally(masterCb: FunctionCb, slaveCb: FunctionCb): Promise<void>;
 };
 
-class ScaleUtil implements ScaleOps {
+export class ScaleUtil implements ScaleOps {
   private static readonly CPUS_COUNT = os.cpus().length;
+  public static readonly WORKER_MAP = new Map<number, Worker>();
 
   async scaleHorizontally(
     masterCb?: FunctionCb,
@@ -18,7 +19,7 @@ class ScaleUtil implements ScaleOps {
     if (cluster.isPrimary) {
       await masterCb?.();
       this.respawnProcesses();
-      IpcHandler.listenToMessageEvent(cluster.workers);
+      IpcHandler.listenToMessageEvent({ workers: cluster.workers });
       return;
     }
 
@@ -27,12 +28,17 @@ class ScaleUtil implements ScaleOps {
 
   private respawnProcesses(): void {
     for (let i = 0; i < ScaleUtil.CPUS_COUNT; i++) {
-      cluster.fork();
+      const worker = cluster.fork();
+      ScaleUtil.WORKER_MAP.set(worker.process.pid, worker);
     }
 
-    cluster.on('exit', (worker) => {
-      console.log(`Worker with id ${worker.process.pid} died. Restarting...`);
-      cluster.fork();
+    cluster.on('exit', ({ process }) => {
+      console.log(`Worker with id ${process.pid} died. Restarting...`);
+      ScaleUtil.WORKER_MAP.delete(process.pid);
+      const respawnedWorker = cluster.fork();
+
+      ScaleUtil.WORKER_MAP.set(respawnedWorker.process.pid, respawnedWorker);
+      IpcHandler.listenToMessageEvent({ worker: respawnedWorker });
     });
   }
 }

--- a/apps/frontend/src/.proto/prediction.proto
+++ b/apps/frontend/src/.proto/prediction.proto
@@ -12,4 +12,5 @@ message PredictionProgressRequest {
 
 message PredictionProgressResponse {
     int32 progress = 1;
+    repeated int32 result = 2;
 }

--- a/apps/frontend/src/app/_services/prediction.service.ts
+++ b/apps/frontend/src/app/_services/prediction.service.ts
@@ -68,6 +68,12 @@ export class PredictionService {
     );
   }
 
+  stopPrediction(jobId: string): Observable<void> {
+    return this.httpClient.delete<void>(
+      `${this.getBackendUrl()}/stop/${jobId}`
+    );
+  }
+
   private getBackendUrl(): string {
     return `${environment.backend_url}/prediction`;
   }

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -24,6 +24,8 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, procast');
+    expect(compiled.querySelector('h1')?.textContent).toContain(
+      'Hello, procast'
+    );
   });
 });

--- a/apps/frontend/src/app/app.config.server.ts
+++ b/apps/frontend/src/app/app.config.server.ts
@@ -7,8 +7,8 @@ import { serverRoutes } from './app.routes.server';
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),
-    provideServerRoutesConfig(serverRoutes)
-  ]
+    provideServerRoutesConfig(serverRoutes),
+  ],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/apps/frontend/src/app/app.routes.server.ts
+++ b/apps/frontend/src/app/app.routes.server.ts
@@ -3,6 +3,6 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 export const serverRoutes: ServerRoute[] = [
   {
     path: '**',
-    renderMode: RenderMode.Prerender
-  }
+    renderMode: RenderMode.Prerender,
+  },
 ];

--- a/apps/frontend/src/app/generic-modal/generic-modal.component.spec.ts
+++ b/apps/frontend/src/app/generic-modal/generic-modal.component.spec.ts
@@ -8,9 +8,8 @@ describe('GenericModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GenericModalComponent]
-    })
-    .compileComponents();
+      imports: [GenericModalComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(GenericModalComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/load-data/load-data.component.spec.ts
+++ b/apps/frontend/src/app/load-data/load-data.component.spec.ts
@@ -8,9 +8,8 @@ describe('LoadDataComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LoadDataComponent]
-    })
-    .compileComponents();
+      imports: [LoadDataComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(LoadDataComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/sidebar/sidebar.component.spec.ts
+++ b/apps/frontend/src/app/sidebar/sidebar.component.spec.ts
@@ -8,9 +8,8 @@ describe('SidebarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SidebarComponent]
-    })
-    .compileComponents();
+      imports: [SidebarComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SidebarComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/start/start.component.html
+++ b/apps/frontend/src/app/start/start.component.html
@@ -31,9 +31,3 @@
     </div>
   </div>
 </section>
-
-<ngx-particles
-  [id]="'start-particles'"
-  [options]="particlesConfig"
-  (particlesLoaded)="particlesLoaded($event)"
-></ngx-particles>

--- a/apps/frontend/src/app/start/start.component.spec.ts
+++ b/apps/frontend/src/app/start/start.component.spec.ts
@@ -8,9 +8,8 @@ describe('StartComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [StartComponent]
-    })
-    .compileComponents();
+      imports: [StartComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(StartComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/start/start.component.ts
+++ b/apps/frontend/src/app/start/start.component.ts
@@ -1,9 +1,7 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { NgParticlesService, NgxParticlesModule } from '@tsparticles/angular';
-import { loadSlim } from '@tsparticles/slim';
+import { NgxParticlesModule } from '@tsparticles/angular';
 import { particlesConfig } from '../common/_particles/particles.config';
-import { Container } from '@tsparticles/engine';
 
 @Component({
   selector: 'app-start',
@@ -12,27 +10,6 @@ import { Container } from '@tsparticles/engine';
   styleUrl: './start.component.scss',
   standalone: true,
 })
-export class StartComponent implements OnInit {
-  private ngParticlesService = inject(NgParticlesService);
+export class StartComponent {
   particlesConfig = particlesConfig;
-
-  ngOnInit(): void {
-    // this.loadNgParticlesEngine();
-  }
-
-  private loadNgParticlesEngine(): void {
-    this.ngParticlesService.init(async (engine) => {
-      console.log(engine);
-
-      // Starting from 1.19.0 you can add custom presets or shape here, using the current tsParticles instance (main)
-      // this loads the tsparticles package bundle, it's the easiest method for getting everything ready
-      // starting from v2 you can add only the features you need reducing the bundle size
-      //await loadFull(engine);
-      await loadSlim(engine);
-    });
-  }
-
-  particlesLoaded(container: Container): void {
-    console.log(container);
-  }
 }

--- a/apps/frontend/src/app/worksheet/worksheet.component.spec.ts
+++ b/apps/frontend/src/app/worksheet/worksheet.component.spec.ts
@@ -8,9 +8,8 @@ describe('WorksheetComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorksheetComponent]
-    })
-    .compileComponents();
+      imports: [WorksheetComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(WorksheetComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/workspace/workspace.component.html
+++ b/apps/frontend/src/app/workspace/workspace.component.html
@@ -96,7 +96,7 @@
         ></ng-container>
       </mat-tab>
     </mat-tab-group>
-    <div class="!h-8 !absolute bottom-2 mx-2">
+    <div class="!h-8 !absolute -top-4 mx-2">
       <button
         mat-mini-fab
         aria-label="Add new sheet"

--- a/apps/frontend/src/app/workspace/workspace.component.html
+++ b/apps/frontend/src/app/workspace/workspace.component.html
@@ -27,7 +27,9 @@
     <ng-container *ngTemplateOutlet="sidebarTemplateRef"></ng-container>
   </div>
 
-  <div class="col-span-3 row-span-2 col-start-1 row-start-5 hidden sm:block">
+  <div
+    class="col-span-3 row-span-2 col-start-1 row-start-5 hidden sm:block relative"
+  >
     <mat-tab-group
       class="px-4 h-full sm:pb-4"
       mat-stretch-tabs="false"
@@ -93,20 +95,17 @@
           *ngTemplateOutlet="worksheetDataTemplateRef"
         ></ng-container>
       </mat-tab>
-      <mat-tab (click)="$event.preventDefault()">
-        <ng-template mat-tab-label>
-          <button
-            mat-fab
-            extended
-            class="!h-8 !pointer-events-none"
-            (click)="addNewSheet($event)"
-          >
-            <span>New Sheet</span>
-            <mat-icon>add</mat-icon>
-          </button>
-        </ng-template>
-      </mat-tab>
     </mat-tab-group>
+    <div class="!h-8 !absolute bottom-2 mx-2">
+      <button
+        mat-mini-fab
+        aria-label="Add new sheet"
+        class="scale-[.6]"
+        (click)="addNewSheet($event)"
+      >
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
   </div>
   <div class="row-span-2 col-start-4 row-start-5 hidden sm:block">
     <ng-template #actionsTemplateRef>

--- a/apps/frontend/src/app/workspace/workspace.component.scss
+++ b/apps/frontend/src/app/workspace/workspace.component.scss
@@ -34,13 +34,13 @@ $not-started-overlay-label: 'Prediction has not started 🚀';
     }
   }
   .mat-mdc-tab-header {
-    @apply mb-2;
+    @apply mb-6;
   }
   .mat-mdc-tab-labels {
     @apply h-full relative flex flex-col;
 
     .mdc-tab.mat-mdc-tab.mat-focus-indicator {
-      @apply h-fit;
+      @apply h-fit py-2;
 
       &:last-child {
         @apply pointer-events-none;

--- a/apps/frontend/src/app/workspace/workspace.component.scss
+++ b/apps/frontend/src/app/workspace/workspace.component.scss
@@ -34,7 +34,7 @@ $not-started-overlay-label: 'Prediction has not started 🚀';
     }
   }
   .mat-mdc-tab-header {
-    @apply mb-6;
+    @apply mt-6;
   }
   .mat-mdc-tab-labels {
     @apply h-full relative flex flex-col;

--- a/apps/frontend/src/app/workspace/workspace.component.spec.ts
+++ b/apps/frontend/src/app/workspace/workspace.component.spec.ts
@@ -8,9 +8,8 @@ describe('WorkspaceComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WorkspaceComponent]
-    })
-    .compileComponents();
+      imports: [WorkspaceComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(WorkspaceComponent);
     component = fixture.componentInstance;

--- a/apps/frontend/src/app/workspace/workspace.component.ts
+++ b/apps/frontend/src/app/workspace/workspace.component.ts
@@ -60,8 +60,10 @@ import {
   filter,
   firstValueFrom,
   map,
+  merge,
   Observable,
   Subject,
+  switchMap,
   take,
   takeUntil,
 } from 'rxjs';
@@ -209,21 +211,23 @@ export class WorkspaceComponent implements OnInit {
 
   chartLegend = true;
 
-  stopPredictionActionButtonConfig: ActionButtonConfig = {
+  private stopPredictionActionButtonConfig: ActionButtonConfig = {
     label: 'Stop',
     iconName: 'cancel',
     clickCallback: () => this.requestCancelled$.next(),
     resolveLinkDisabled: () => false,
   };
 
+  private generatePredictionActionButtonConfig: ActionButtonConfig = {
+    label: 'Generate',
+    iconName: 'play',
+    clickCallback: this.schedulePrediction.bind(this),
+    resolveLinkDisabled: () =>
+      !this.canStartPrediction || this.isPredictionInProgress,
+  };
+
   actionButtonConfigList: Array<ActionButtonConfig> = [
-    {
-      label: 'Generate',
-      iconName: 'play',
-      clickCallback: this.schedulePrediction.bind(this),
-      resolveLinkDisabled: () =>
-        !this.canStartPrediction || this.isPredictionInProgress,
-    },
+    this.generatePredictionActionButtonConfig,
     {
       label: 'Load',
       iconName: 'import',
@@ -268,6 +272,7 @@ export class WorkspaceComponent implements OnInit {
     this.generateRandomData();
 
     this.observeCachedTrainConfigOptions();
+    this.observeComputationStopRequested();
   }
 
   openLoadDataModal(): void {
@@ -294,49 +299,35 @@ export class WorkspaceComponent implements OnInit {
   }
 
   async schedulePrediction(): Promise<void> {
-    const predictionActionButtonConfig = this.actionButtonConfigList.shift()!;
-
     try {
       this.lastPredictionFailed = false;
       this.computationProgressBarMode = 'query';
       this.isPredictionInProgress = true;
-      // let scheduledPrediction: Array<number> = [];
+      this.computationProgressValue = 0;
 
       const data = Array.from(this.worksheetData.values()).map(
         (entry) => entry.value
       );
-      this.actionButtonConfigList.unshift(
-        this.stopPredictionActionButtonConfig
-      );
+      this.actionButtonConfigList[0] = this.stopPredictionActionButtonConfig;
+
+      this.changeDetectorRef.detectChanges();
 
       const scheduledPredictionResult = await firstValueFrom(
         this.predictionService
           .schedulePrediction(data, this.trainingConfig!)
-          .pipe(takeUntil(this.requestCancelled$), defaultIfEmpty(null))
+          .pipe(defaultIfEmpty(null))
       );
-
-      this.actionButtonConfigList.shift();
-      this.actionButtonConfigList.unshift(predictionActionButtonConfig);
-
-      this.computationProgressValue = scheduledPredictionResult ? 100 : 0;
-      this.computationProgressBarMode = 'determinate';
-
-      this.isPredictionInProgress = false;
 
       if (scheduledPredictionResult?.jobId != null) {
         this.observePredictionProgress(scheduledPredictionResult.jobId);
+        this.scheduledPredictionJobId = scheduledPredictionResult?.jobId ?? '';
+      } else {
+        this.alertService.showErrorSnackBar(
+          'Starting of prediction has occurred an error. JobId is not specified.'
+        );
       }
-
-      this.scheduledPredictionJobId = scheduledPredictionResult?.jobId ?? '';
     } catch (error: unknown) {
-      this.actionButtonConfigList.shift();
-      this.actionButtonConfigList.unshift(predictionActionButtonConfig);
-
-      this.isPredictionInProgress = false;
-      this.lastPredictionFailed = true;
-
-      this.computationProgressBarMode = 'determinate';
-      this.computationProgressValue = 100;
+      this.clearComputationProgress(true);
 
       if (TypeHelper.isUnknownAnObject(error, 'message')) {
         this.alertService.showErrorSnackBar(error.message);
@@ -622,17 +613,57 @@ export class WorkspaceComponent implements OnInit {
   private observePredictionProgress(jobId: string): void {
     const computationCompleted$ = new Subject<void>();
     this.isPredictionInProgress = true;
+    this.computationProgressBarMode = 'determinate';
 
     this.predictionService
       .observePredictionProgress(jobId)
-      .pipe(filter(Boolean), takeUntil(computationCompleted$))
-      .subscribe(({ progress }) => {
+      .pipe(
+        filter(Boolean),
+        takeUntil(merge(computationCompleted$, this.requestCancelled$))
+      )
+      .subscribe(({ progress, result }) => {
         this.computationProgressValue = progress;
         if (progress === WorkspaceComponent.PREDICTION_COMPLETED_VALUE) {
           this.isPredictionInProgress = false;
+          this.actionButtonConfigList[0] =
+            this.generatePredictionActionButtonConfig;
+          debugger;
+          if (result.length > 0) {
+            this.applyGeneratedPrediction(result);
+          }
           computationCompleted$.next();
         }
         this.changeDetectorRef.detectChanges();
       });
+  }
+
+  private observeComputationStopRequested(): void {
+    this.requestCancelled$
+      .pipe(
+        take(1),
+        takeUntilDestroyed(this.#destroyRef),
+        switchMap(() =>
+          this.predictionService.stopPrediction(
+            String(this.scheduledPredictionJobId)
+          )
+        )
+      )
+      .subscribe(() => {
+        this.clearComputationProgress();
+      });
+  }
+
+  private clearComputationProgress(didFail = false): void {
+    this.actionButtonConfigList[0] = this.generatePredictionActionButtonConfig;
+    this.computationProgressValue = didFail ? 100 : 0;
+    this.isPredictionInProgress = false;
+    this.computationProgressBarMode = 'determinate';
+    this.scheduledPredictionJobId = '';
+
+    if (didFail) {
+      this.lastPredictionFailed = true;
+    }
+
+    this.changeDetectorRef.detectChanges();
   }
 }

--- a/apps/frontend/src/app/workspace/workspace.component.ts
+++ b/apps/frontend/src/app/workspace/workspace.component.ts
@@ -640,7 +640,6 @@ export class WorkspaceComponent implements OnInit {
   private observeComputationStopRequested(): void {
     this.requestCancelled$
       .pipe(
-        take(1),
         takeUntilDestroyed(this.#destroyRef),
         switchMap(() =>
           this.predictionService.stopPrediction(

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:front": "npx nx run frontend:serve --host=0.0.0.0 --disable-host-check --skip-nx-cache",
     "dev:back": "npx nx run backend:serve",
     "reset": "npm cache clean --force && npx nx reset && npx nx clear-cache",
+    "fix:prettier": "pnpm prettier --write \"**/*.{ts,js,scss.html}\"",
+    "fix:eslint": "pnpm eslint \"**/*.{ts,js,scss.html}\" --fix",
     "front-proto:gen:win": "for /f %G in ('dir /b apps\\frontend\\src\\.proto\\*.proto') do grpc_tools_node_protoc --plugin=protoc-gen-ng=.\\node_modules\\.bin\\protoc-gen-ng.cmd --ng_out=apps\\frontend\\src\\.proto\\ -I apps\\frontend\\src\\.proto\\ apps\\frontend\\src\\.proto\\%G",
     "run:grpc-proxy:dev": "grpcwebproxy-v0.15.0-win64.exe --backend_addr=localhost:9090 --run_tls_server=false --allowed_origins=http://localhost:4200 --server_http_max_write_timeout=900s"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:back": "npx nx run backend:serve",
     "reset": "npm cache clean --force && npx nx reset && npx nx clear-cache",
     "front-proto:gen:win": "for /f %G in ('dir /b apps\\frontend\\src\\.proto\\*.proto') do grpc_tools_node_protoc --plugin=protoc-gen-ng=.\\node_modules\\.bin\\protoc-gen-ng.cmd --ng_out=apps\\frontend\\src\\.proto\\ -I apps\\frontend\\src\\.proto\\ apps\\frontend\\src\\.proto\\%G",
-    "run:grpc-proxy:dev": "grpcwebproxy-v0.15.0-win64.exe --backend_addr=localhost:9090 --run_tls_server=false --allowed_origins=http://localhost:4200"
+    "run:grpc-proxy:dev": "grpcwebproxy-v0.15.0-win64.exe --backend_addr=localhost:9090 --run_tls_server=false --allowed_origins=http://localhost:4200 --server_http_max_write_timeout=900s"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
MR considers rewrite "stop prediction" functionality in bullmq routine.

One problem was detected. Every time when subprocess was terminated (stopping of tensorflow model fitting computation), job responsible for computation was moving to stalled state. To prevent that option to `train-model.consumer.ts` was added:
```
@Processor({ name: 'prediction' }, { maxStalledCount: 0 })
```
With that option, job will be moved to fail state every time when hit "stalled" state (e.g., stopping of computation). 